### PR TITLE
Update _stylesheets.html to use parent's protocol

### DIFF
--- a/_includes/_stylesheets.html
+++ b/_includes/_stylesheets.html
@@ -1,4 +1,4 @@
     <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">-->
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}" />
-    <link href="http://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic" rel="stylesheet" type="text/css">
     <link href="font-awesome-4.1.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
There's a mixed content warning for the Google font url.
Updated "http://" to "//" to use the parent pages protocol.